### PR TITLE
Fix chat options, user labels and voice/STT support

### DIFF
--- a/assets/js/conversations.js
+++ b/assets/js/conversations.js
@@ -48,6 +48,7 @@
     cont.__amBound = true;
 
     // --- Pinned agents helpers ---
+    const PIN_ICON = '<img src="https://wa4u.ai/wp-content/uploads/2025/09/pin.svg" alt="pin">';
     function getPins() {
       try { return JSON.parse(localStorage.getItem('amPinnedAgents') || '[]'); }
       catch (_) { return []; }
@@ -62,7 +63,7 @@
         if (existing) {
           existing.classList.add('pinned');
           const btn = existing.querySelector('.am-pin-btn');
-          if (btn) btn.textContent = 'Unpin';
+          if (btn) btn.innerHTML = PIN_ICON + 'Unpin';
           return;
         }
         const li = document.createElement('li');
@@ -84,7 +85,7 @@
         li.appendChild(span);
         const menuCont = document.createElement('div');
         menuCont.className = 'am-agent-menu-container';
-        menuCont.innerHTML = '<button type="button" class="am-agent-menu-btn" aria-label="Open menu"><svg width="12" height="4" viewBox="0 0 12 4" fill="none" xmlns="http://www.w3.org/2000/svg"><ellipse cx="1.92051" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/><ellipse cx="5.99082" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/><ellipse cx="10.0572" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/></svg></button><div class="am-agent-menu"><button type="button" class="am-new-chat-btn" aria-label="New chat">New Chat</button><button type="button" class="am-pin-btn" aria-label="Unpin">Unpin</button></div>';
+        menuCont.innerHTML = `<button type="button" class="am-agent-menu-btn" aria-label="Open menu"><svg width="12" height="4" viewBox="0 0 12 4" fill="none" xmlns="http://www.w3.org/2000/svg"><ellipse cx="1.92051" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/><ellipse cx="5.99082" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/><ellipse cx="10.0572" cy="1.70045" rx="1.52597" ry="1.52076" fill="#3A354E"/></svg></button><div class="am-agent-menu"><button type="button" class="am-new-chat-btn" aria-label="New chat">New Chat</button><button type="button" class="am-pin-btn" aria-label="Unpin">${PIN_ICON}Unpin</button></div>`;
         li.appendChild(menuCont);
         list.insertBefore(li, list.firstChild);
       });
@@ -228,7 +229,7 @@
           const list = item.parentElement;
           if (list) list.insertBefore(item, list.firstChild);
         }
-        pinBtn.textContent = item.classList.contains('pinned') ? 'Unpin' : 'Pin';
+        pinBtn.innerHTML = PIN_ICON + (item.classList.contains('pinned') ? 'Unpin' : 'Pin');
         pinBtn.closest('.am-agent-menu')?.classList.remove('open');
         return;
       }


### PR DESCRIPTION
## Summary
- Simplify chat options shortcode with vertical layout, save button and per-agent persistence
- Show logged-in user name instead of generic "Me" in chat bubbles
- Improve voice and STT handling with better MediaRecorder support and ensure pin icon remains visible

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/chat.js`
- `node --check assets/js/conversations.js`


------
https://chatgpt.com/codex/tasks/task_b_68b51ac086ac832483abdf850cddc684