### PR TITLE
Enable chat tone/length options and dynamic history cleanup

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -660,8 +660,14 @@ ul.am-agent-list li:first-child {
 /* Minimal chat customization options */
 .am-chat-options {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px;
+  background: #f7f7f8;
+  border-radius: 8px;
   margin-bottom: 10px;
+  max-width: 220px;
 }
 
 .am-chat-options label {
@@ -669,7 +675,40 @@ ul.am-agent-list li:first-child {
   color: #3A354E;
 }
 
-.am-chat-options select {
+.am-chat-options select,
+.am-chat-options button {
   font-size: 13px;
+  border: none;
+  background: #fff;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.am-chat-options button {
+  background: #3A354E;
+  color: #fff;
+  cursor: pointer;
+}
+
+.am-chat-info {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.am-chat-info-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.am-chat-toast {
+  font-size: 12px;
+  color: #fff;
+  background: #3A354E;
+  padding: 2px 6px;
+  border-radius: 4px;
+  align-self: flex-end;
 }
 

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -436,6 +436,11 @@
         const replyHtml = sanitizeReply(rawReply);
         const replyText = stripHtml(replyHtml);
 
+        // Prepare TTS as early as possible
+        addPlayToLastAIBubble(replyText);
+        const lastPlayBtn = typing.querySelector('.play-btn');
+        if (lastPlayBtn && window.AM_AUTO_AUDIO) lastPlayBtn.click();
+
         const bubbleEl = typing.querySelector('.bubble');
         await typeInto(bubbleEl, escapeHtml(replyText));
         bubbleEl.innerHTML = replyHtml;
@@ -465,10 +470,7 @@
         const row = typing.querySelector('.am-feedback-row');
         if (row) addFeedbackButtons(row, replyText, data.assistant_message_id);
 
-        // Automatically play TTS for every assistant response when enabled
-        addPlayToLastAIBubble(replyText);
-        const lastPlayBtn = typing.querySelector('.play-btn');
-        if (lastPlayBtn && window.AM_AUTO_AUDIO) lastPlayBtn.click(); // Trigger TTS playback automatically
+        // Automatically play TTS button added earlier
       } catch (err) {
         console.error('Chat error:', err);
         const b = typing.querySelector('.bubble');

--- a/assets/js/conversations.js
+++ b/assets/js/conversations.js
@@ -7,25 +7,33 @@
   const AM_REST = (window.AM_REST || '/wp-json/') + '';
   const AM_NONCE = (window.AM_NONCE || '') + '';
   const deletingCids = new Set();
+  function removeEmptyGroup(list) {
+    if (!list || !list.classList?.contains('am-chat-list')) return;
+    if (list.children.length === 0) {
+      const header = list.previousElementSibling;
+      if (header && header.tagName.toLowerCase() === 'h5') header.remove();
+      list.remove();
+    }
+  }
+
   function moveChatItemToDateGroup(item, newDateKey) {
-    // Find the correct group (h5 with date label)
+    const oldList = item.parentElement;
     const container = item.closest('.am-assistant-chats-container');
     if (!container) return;
     let groupHeader = Array.from(container.querySelectorAll('h5')).find(h => h.textContent === newDateKey);
     let groupList;
     if (!groupHeader) {
-      // Create new group if not exists
       groupHeader = document.createElement('h5');
       groupHeader.textContent = newDateKey;
       groupList = document.createElement('ul');
       groupList.className = 'am-chat-list';
-      // Insert at top
       container.insertBefore(groupHeader, container.querySelector('h5'));
       container.insertBefore(groupList, groupHeader.nextSibling);
     } else {
       groupList = groupHeader.nextElementSibling;
     }
     groupList.appendChild(item);
+    removeEmptyGroup(oldList);
   }
 
   function getTodayLabel() {
@@ -303,7 +311,9 @@
             if (!r.ok) throw new Error('Delete failed');
 
             // Remove from list
+            const parentList = item.parentElement;
             item.remove();
+            removeEmptyGroup(parentList);
 
             // Check if viewing deleted conversation
             const currentCid = new URL(window.location.href).searchParams.get('cid');
@@ -342,7 +352,9 @@
           if (!r.ok) throw new Error('API error');
           
           // Remove from DOM
+          const parentList2 = item.parentElement;
           item.remove();
+          removeEmptyGroup(parentList2);
 
           // Check if viewing deleted conversation
           const currentCid = new URL(window.location.href).searchParams.get('cid');
@@ -377,7 +389,7 @@
 
     // Add this function inside init scope
     function updateConversationTimestamp(item) {
-      // Move conversation to Today section
+      const oldList = item.parentElement;
       const todayHeader = Array.from(cont.querySelectorAll('h5')).find(h => h.textContent === 'Today');
       const todayList = todayHeader?.nextElementSibling;
       
@@ -398,6 +410,7 @@
       } else if (todayList) {
         todayList.insertBefore(item, todayList.firstChild);
       }
+      removeEmptyGroup(oldList);
     }
 
     // Helper to ensure Today section exists

--- a/includes/rest.php
+++ b/includes/rest.php
@@ -79,6 +79,9 @@ function am_rest_chat(WP_REST_Request $req) {
         $agent_id = (int)$req->get_param('agent_id');
         $message  = trim((string)$req->get_param('message'));
         $conv_uid = sanitize_text_field($req->get_param('conversation_uid') ?: '');
+        $opts     = (array)$req->get_param('options');
+        $tone     = sanitize_text_field($opts['tone'] ?? '');
+        $length   = sanitize_text_field($opts['length'] ?? '');
         
         if(!$agent_id || $message==='') {
             ob_end_clean();
@@ -122,6 +125,15 @@ function am_rest_chat(WP_REST_Request $req) {
           $msgs = [ am_build_agent_system_message($agent_id, $summary) ];
           foreach($history as $h){ $msgs[] = ['role'=>$h['role'],'content'=>$h['content']]; }
           $msgs[] = ['role'=>'system','content'=>"Always respond directly to the user's most recent message. Be contextual."];
+
+          if($tone){
+            $msgs[] = ['role'=>'system','content'=>"Use a {$tone} tone in your replies."];
+          }
+          if($length === 'concise'){
+            $msgs[] = ['role'=>'system','content'=>'Keep responses concise.'];
+          } elseif($length === 'detailed'){
+            $msgs[] = ['role'=>'system','content'=>'Provide detailed and thorough responses.'];
+          }
 
           $reply = am_openai_chat_complete($model, $msgs, $temp);
           if(is_wp_error($reply)) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -545,32 +545,41 @@ function am_format_date_group($date) {
 // Shortcode for minimal chat customization options
 function am_chat_options_shortcode(){
   $uid = wp_generate_uuid4();
+  $agent_id = isset($_GET['agent_id']) ? (int)$_GET['agent_id'] : 0;
+  $avatar = $agent_id ? get_the_post_thumbnail_url($agent_id,'thumbnail') : '';
+  $name   = $agent_id ? get_the_title($agent_id) : '';
   ob_start(); ?>
   <div class="am-chat-options" id="am-chat-options-<?php echo esc_attr($uid); ?>">
-    <div>
-      <label for="am-chat-tone-<?php echo esc_attr($uid); ?>">Tone:</label>
-      <select id="am-chat-tone-<?php echo esc_attr($uid); ?>">
-        <option value="">Default</option>
-        <option value="friendly">Friendly</option>
-        <option value="professional">Professional</option>
-        <option value="humorous">Humorous</option>
-      </select>
-    </div>
-    <div>
-      <label for="am-chat-length-<?php echo esc_attr($uid); ?>">Length:</label>
-      <select id="am-chat-length-<?php echo esc_attr($uid); ?>">
-        <option value="">Default</option>
-        <option value="concise">Concise</option>
-        <option value="detailed">Detailed</option>
-      </select>
-    </div>
+    <?php if($avatar || $name): ?>
+      <div class="am-chat-info">
+        <?php if($avatar): ?><img src="<?php echo esc_url($avatar); ?>" alt="<?php echo esc_attr($name); ?>" class="am-chat-info-avatar" /><?php endif; ?>
+        <?php if($name): ?><span class="am-chat-info-name"><?php echo esc_html($name); ?></span><?php endif; ?>
+      </div>
+    <?php endif; ?>
+    <label for="am-chat-tone-<?php echo esc_attr($uid); ?>">Tone:</label>
+    <select id="am-chat-tone-<?php echo esc_attr($uid); ?>">
+      <option value="">Default</option>
+      <option value="friendly">Friendly</option>
+      <option value="professional">Professional</option>
+      <option value="humorous">Humorous</option>
+    </select>
+
+    <label for="am-chat-length-<?php echo esc_attr($uid); ?>">Length:</label>
+    <select id="am-chat-length-<?php echo esc_attr($uid); ?>">
+      <option value="">Default</option>
+      <option value="concise">Concise</option>
+      <option value="detailed">Detailed</option>
+    </select>
+
     <button type="button" id="am-chat-save-<?php echo esc_attr($uid); ?>">Save</button>
+    <div class="am-chat-toast" id="am-chat-toast-<?php echo esc_attr($uid); ?>" style="display:none">Saved</div>
   </div>
   <script>
   (function(){
     const toneSel = document.getElementById('am-chat-tone-<?php echo esc_attr($uid); ?>');
     const lenSel  = document.getElementById('am-chat-length-<?php echo esc_attr($uid); ?>');
     const saveBtn = document.getElementById('am-chat-save-<?php echo esc_attr($uid); ?>');
+    const toast   = document.getElementById('am-chat-toast-<?php echo esc_attr($uid); ?>');
     const params  = new URLSearchParams(location.search);
     const agent   = params.get('agent_id') || '0';
     const key     = `amChatOpts-agent-${agent}`;
@@ -584,6 +593,10 @@ function am_chat_options_shortcode(){
       };
       try { localStorage.setItem(key, JSON.stringify(opts)); } catch(_){ }
       window.AM_CHAT_OPTS[key] = opts;
+      if (toast) {
+        toast.style.display = 'block';
+        setTimeout(()=>{ toast.style.display = 'none'; }, 1000);
+      }
     }
 
     let stored = {};


### PR DESCRIPTION
## Summary
- Send selected tone and length to chat API and apply as system instructions
- Restyle chat options with avatar, toast confirmation, and vertical layout
- Speed up voice responses by preloading TTS
- Remove empty conversation groups after updates or deletions

## Testing
- `php -l includes/rest.php`
- `php -l includes/shortcodes.php`
- `node -e "console.log('node version', process.version)"`


------
https://chatgpt.com/codex/tasks/task_b_68b535b88f4c8324a23dc7870c8c152f