### PR TITLE
Ensure voice call stays active and improve send button

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -500,6 +500,20 @@
   bottom: -100%;
 }
 
+.am-voice-call-overlay .assistant-meta {
+  text-align: center;
+}
+
+.am-voice-call-overlay .assistant-name {
+  margin: 16px 0 4px;
+  font-size: 24px;
+}
+
+.am-voice-call-overlay .assistant-description {
+  margin: 0;
+  opacity: .8;
+}
+
 .am-voice-call-btn {
   padding: 12px 24px;
   font-size: 18px;

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -145,6 +145,7 @@
     // -----------------------
     const sendBtn = root.querySelector('.send');
     const callBtn = root.querySelector('.am-voice-call-btn');
+    let toggleCallBtn = null;
     const inputInner = root.querySelector('.openai-input-inner');
     const transcribingImg = root.dataset.transcribingImg || 'https://wa4u.ai/wp-content/uploads/2025/09/transcribing.svg';
     let sttOverlay = null;
@@ -203,8 +204,11 @@
     }
 
     if (input && callBtn) {
-      input.addEventListener('focus', () => { callBtn.style.display = 'none'; });
-      input.addEventListener('blur', () => { setTimeout(() => { callBtn.style.display = ''; }, 0); });
+      toggleCallBtn = () => {
+        callBtn.style.display = input.value.trim() ? 'none' : '';
+      };
+      input.addEventListener('input', toggleCallBtn);
+      toggleCallBtn();
     }
 
     if (voiceBtn && navigator.mediaDevices) {
@@ -371,11 +375,10 @@
       const text = (input.value || '').trim();
       if (!text) return;
 
-      if (callBtn) callBtn.style.display = '';
-
       appendBubble('user', escapeHtml(text));
       input.value = '';
       autosize();
+      if (toggleCallBtn) toggleCallBtn();
 
       const typing = appendBubble('ai', '<div class="typing-indicator">Typing...</div>', false);
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -102,10 +102,13 @@ add_shortcode('am_chat', function(){
       <?php if($avatar): ?>
         <div class="am-voice-avatar-wrap">
           <img class="assistant-avatar" src="<?php echo esc_url($avatar); ?>" alt="<?php echo esc_attr($name); ?>">
-          
+          <div class="am-voice-level"></div>
         </div>
-        <div class="am-voice-level"></div>
       <?php endif; ?>
+      <div class="assistant-meta">
+        <h2 class="assistant-name"><?php echo esc_html($name); ?></h2>
+        <p class="assistant-description"><?php echo esc_html($subtitle); ?></p>
+      </div>
       <div class="am-voice-call-controls">
         <button type="button" class="am-voice-call-mute" aria-label="Mute Microphone">
           <img class="am-mic-on" src="https://wa4u.ai/wp-content/uploads/2025/09/not-muted.svg" alt="mic on">
@@ -342,6 +345,9 @@ add_shortcode('am_chat', function(){
           setState('Idle');
         }
         busy = false;
+        if (mediaRecorder && mediaRecorder.state === 'inactive') {
+          try { mediaRecorder.start(4000); } catch(_) {}
+        }
         if (pendingChunk && !busy) {
           const b = pendingChunk; pendingChunk = null; await processChunk(b);
         }


### PR DESCRIPTION
## Summary
- Keep MediaRecorder active between voice responses to maintain continuous voice chat
- Fix send button requiring double click and hide/show call button based on text presence
- Display assistant name and description in voice call overlay with styling

## Testing
- `php -l includes/shortcodes.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b54a23f9448324b0efeed81915bd22