### PR TITLE
Improve voice chat reliability and typing indicator

### DIFF
--- a/assets/css/am-chat.css
+++ b/assets/css/am-chat.css
@@ -715,3 +715,26 @@ ul.am-agent-list li:first-child {
   align-self: flex-end;
 }
 
+/* Typing indicator animation */
+.typing-indicator {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.typing-indicator span {
+  width: 6px;
+  height: 6px;
+  background: #999;
+  border-radius: 50%;
+  opacity: .2;
+  animation: am-typing 1s infinite;
+}
+
+.typing-indicator span:nth-child(2) { animation-delay: .2s; }
+.typing-indicator span:nth-child(3) { animation-delay: .4s; }
+
+@keyframes am-typing {
+  0%,80%,100% { opacity: .2; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-3px); }
+}
+


### PR DESCRIPTION
## Summary
- Avoid repeated STT failures by resetting audio stream and skipping empty recordings
- Replace plain "Typing..." text with animated dots
- Only auto-scroll after user activity so older chats open at the top

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b55765080c832496c201f26cd572e5