### PR TITLE
Fix voice chat audio context and scroll behavior

### DIFF
--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -29,6 +29,8 @@
     const avatarUrl     = root.dataset.avatarUrl || '';
     const scrollIcon    = root.dataset.scrollIcon || 'https://wa4u.ai/wp-content/uploads/2025/08/nav-arrow-down.svg';
 
+    let initialLoad = true;
+
     function getChatKey(){
       return `amChatOpts-agent-${agentId}`;
     }
@@ -130,20 +132,16 @@
       root.AM_setUserLocked  = (val) => { userLocked = !!val; };
       root.AM_scrollBtn      = goEndBtn;
 
-      // Estado inicial
-      if (convUid) {
-        userLocked = true;
-        goEndBtn.style.display = 'block';
-      } else {
-        updateState();
-        scrollToBottom(false);
-      }
+      // Estado inicial: no auto-scroll al cargar
+      userLocked = true;
+      goEndBtn.style.display = 'block';
     })();
 
     // -----------------------
     // Bienvenida (después de montar auto-scroll)
     // -----------------------
     appendBubble('ai', escapeHtml(welcome), true);
+    initialLoad = false;
 
     // -----------------------
     // STT using Whisper via MediaRecorder
@@ -844,7 +842,14 @@ function extractSuggestions(raw, replyOrRaw) {
 
       messagesEl.appendChild(wrap);
 
-      if (shouldStick && root.AM_scrollToBottom) root.AM_scrollToBottom(true);
+      if (role === 'ai') {
+        if (!initialLoad) {
+          if (root.AM_setUserLocked) root.AM_setUserLocked(false);
+          if (root.AM_scrollToBottom) root.AM_scrollToBottom(true);
+        }
+      } else if (shouldStick && root.AM_scrollToBottom) {
+        root.AM_scrollToBottom(true);
+      }
       return wrap;
     }
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -196,7 +196,10 @@ add_shortcode('am_chat', function(){
       function startTtsViz(audio){
         if (!levelCircle) return;
         if (ttsVizInterval) clearInterval(ttsVizInterval);
-        if (ttsCtx) { try { ttsCtx.close(); } catch(_) {} }
+        if (ttsCtx) {
+          try { ttsCtx.close().catch(()=>{}); } catch(_) {}
+          ttsCtx = null;
+        }
         const AudioCtx = window.AudioContext || window.webkitAudioContext;
         ttsCtx = new AudioCtx();
         const src = ttsCtx.createMediaElementSource(audio);
@@ -215,7 +218,10 @@ add_shortcode('am_chat', function(){
         },100);
         const clear = () => {
           clearInterval(ttsVizInterval); ttsVizInterval=null; levelCircle.style.transform='translate(-50%, -50%) scale(1)';
-          try { ttsCtx.close(); } catch(_) {}
+          if (ttsCtx) {
+            ttsCtx.close().catch(()=>{});
+            ttsCtx = null;
+          }
         };
         audio.addEventListener('ended', clear, {once:true});
         audio.addEventListener('pause', clear, {once:true});
@@ -449,7 +455,7 @@ add_shortcode('am_chat', function(){
         try { mediaRecorder && mediaRecorder.stop(); } catch(_) {}
         if (micVizInterval){ clearInterval(micVizInterval); micVizInterval=null; }
         if (ttsVizInterval){ clearInterval(ttsVizInterval); ttsVizInterval=null; }
-        if (ttsCtx){ try{ ttsCtx.close(); } catch(_){} ttsCtx=null; }
+        if (ttsCtx){ ttsCtx.close().catch(()=>{}); ttsCtx=null; }
         if (avatarImg) avatarImg.style.transform='scale(1)';
         if (levelCircle) levelCircle.style.transform='translate(-50%, -50%) scale(1)';
         if (micStream){ micStream.getTracks().forEach(t=>t.stop()); micStream=null; }


### PR DESCRIPTION
## Summary
- prevent auto-scrolling on initial load but always scroll after assistant replies
- handle AudioContext closure safely to avoid InvalidStateError

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/chat.js`


------
https://chatgpt.com/codex/tasks/task_b_68b55a5e19548324b54bad63eb443b6d